### PR TITLE
Add fault icons for org.knx (KNX smoke sensor capabilities)

### DIFF
--- a/org.knx/knx_acknowledge_fault.svg
+++ b/org.knx/knx_acknowledge_fault.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <title>knx_acknowledge_fault</title>
+ <g fill="#000" fill-rule="evenodd">
+  <path d="M32 4 2 60h60z M32 12 9.5 56h45z"/>
+  <path d="M28 36l-6-6-4 4 10 10 18-22-4-4z"/>
+ </g>
+</svg>

--- a/org.knx/knx_failure_230v.svg
+++ b/org.knx/knx_failure_230v.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <title>knx_failure_230v</title>
+ <g fill="#000" fill-rule="evenodd">
+  <path d="M28 2 6 36h14L14 62 40 26H24z"/>
+  <path d="M48 32 30 60h36z M48 38l12 18H36z"/>
+  <rect x="47" y="42" width="2" height="8"/>
+  <rect x="47" y="52" width="2" height="2"/>
+ </g>
+</svg>

--- a/org.knx/knx_failure_smoke.svg
+++ b/org.knx/knx_failure_smoke.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <title>knx_failure_smoke</title>
+ <g fill="#000" fill-rule="nonzero">
+  <path d="M28 4a22 22 0 1 0 4.5 43.534 11 11 0 0 1-.5-3.284A18 18 0 1 1 46 28.34a11 11 0 0 1 3.34 1.412A22 22 0 0 0 28 4z"/>
+  <rect x="12" y="26" width="6" height="4" rx="1"/>
+  <rect x="22" y="26" width="6" height="4" rx="1"/>
+  <rect x="32" y="26" width="6" height="4" rx="1"/>
+  <path d="M44 32 26 60h36z M44 38l12 18H32z" fill-rule="evenodd"/>
+  <rect x="43" y="42" width="2" height="8"/>
+  <rect x="43" y="52" width="2" height="2"/>
+ </g>
+</svg>

--- a/org.knx/knx_failure_temperature.svg
+++ b/org.knx/knx_failure_temperature.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <title>knx_failure_temperature</title>
+ <g fill="#000" fill-rule="evenodd">
+  <path d="M20 4a8 8 0 0 1 8 8v24.6a12 12 0 1 1-16 0V12a8 8 0 0 1 8-8zm0 4a4 4 0 0 0-4 4v26.2a8 8 0 1 0 8 0V12a4 4 0 0 0-4-4zm0 14a2 2 0 0 1 2 2v14.6a4 4 0 1 1-4 0V24a2 2 0 0 1 2-2z"/>
+  <path d="M44 32 26 60h36z M44 38l12 18H32z"/>
+  <rect x="43" y="42" width="2" height="8"/>
+  <rect x="43" y="52" width="2" height="2"/>
+ </g>
+</svg>


### PR DESCRIPTION
**App ID:** `org.knx`

These icons are needed for [athombv/org.knx#85](https://github.com/athombv/org.knx/pull/85), which extends the KNX smoke sensor with the full set of fault and signalling channels exposed by Gira smoke alarm objects.

Adds 4 monochrome 64x64 SVGs under `org.knx/`:

- `knx_failure_smoke.svg` — smoke sensor failure
- `knx_failure_temperature.svg` — temperature sensor failure
- `knx_failure_230v.svg` — 230V power failure
- `knx_acknowledge_fault.svg` — reset/acknowledge button

The 5th new capability in that PR (`knx_alarm_signal`, the siren control) reuses the existing `homey capability Icons/alarm_siren.svg` — no new file needed.

These are first-pass drafts in the existing flat monochrome style — happy to iterate if the design team prefers a different direction.

cc @wlcrs